### PR TITLE
Some minor changes in caps plugin

### DIFF
--- a/src/caps.js
+++ b/src/caps.js
@@ -152,7 +152,7 @@ define(['jslix/fields', 'jslix/stanzas', 'jslix/jid',
                 }
                 this._jid_cache[top.from.toString()] = node;
                 if(old_data != data){
-                    this.signals.caps_changed.dispatch(top.from, data);
+                    this.signals.caps_changed.dispatch(top.from, JSON.parse(data));
                 }
             }
             return stanzas.EmptyStanza.create();


### PR DESCRIPTION
Some minor changes in caps plugin:
1. don't initialize _cached_presence in constructor;
2. don't call getItem twice;
3. transfer to a signal handler object instead of a string.
