### PR TITLE
Some minor changes in caps plugin

### DIFF
--- a/src/caps.js
+++ b/src/caps.js
@@ -29,7 +29,6 @@ define(['jslix/fields', 'jslix/stanzas', 'jslix/jid',
         );
         this._jid_cache = {};
         this._broken_nodes = [];
-        this._cached_presence;
     }
 
     var caps = plugin.prototype,


### PR DESCRIPTION
Some minor changes in caps plugin:
1. don't initialize _cached_presence in constructor;
2. don't call getItem twice;
3. transfer to a signal handler object instead of a string.
